### PR TITLE
Fix type for `filter_` in `IntelliClimaECO`

### DIFF
--- a/pyintelliclima/intelliclima_types.py
+++ b/pyintelliclima/intelliclima_types.py
@@ -181,8 +181,8 @@ class IntelliClimaECO:
     tperc: str | None
     fcool: str  # probably referring to 'free cooling' feature in summer-mode
     ws: str  # winter/summer mode ("0" = winter, "1" = summer)
-    filter_from: str
-    filter_active: str
+    filter_from: str | None
+    filter_active: str | None
     timezone: str | None
     co2: str | None
     sanification: str | None


### PR DESCRIPTION
Fix https://github.com/dvdinth/pyintelliclima/issues/1

I tested it manually in my local HA installation.